### PR TITLE
Feature/shortio support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,20 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-curl": "*",
-        "illuminate/contracts": "^8.53",
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^7.0",
+        "illuminate/config": "^8.73",
+        "illuminate/contracts": "^8.73",
         "phplicengine/bitly": "^1.0"
     },
     "require-dev": {
-        "brianium/paratest": "^6.2",
-        "nunomaduro/collision": "^5.3",
-        "orchestra/testbench": "^6.15",
+        "brianium/paratest": "^6.3",
+        "nunomaduro/collision": "^5.10",
+        "orchestra/testbench": "^6.23",
         "phpunit/phpunit": "^9.3",
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.6",
-        "vimeo/psalm": "^4.8"
+        "vimeo/psalm": "^4.13"
     },
     "autoload": {
         "psr-4": {

--- a/config/shorten-urls.php
+++ b/config/shorten-urls.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CarAndClassic\LaravelShortenUrls\Services\Bitly;
+use CarAndClassic\LaravelShortenUrls\Services\Shortio;
 
 return [
 
@@ -24,6 +25,13 @@ return [
              */
             'curl_options' => [
             ],
-        ]
+        ],
+        'shortio' => [
+            'service_class' => Shortio::class,
+
+            'api_key' => env('SHORTIO_API_KEY', ''),
+
+            'domain' => env('SHORTIO_API_DOMAIN', ''),
+        ],
     ]
 ];

--- a/src/Commands/LaravelShortenUrlsCommand.php
+++ b/src/Commands/LaravelShortenUrlsCommand.php
@@ -14,7 +14,7 @@ class LaravelShortenUrlsCommand extends Command
     protected $signature = 'url:shorten {url : The URL to shorten}';
 
     /** @var string $description */
-    protected $description = 'Shorten an URL using the registered service';
+    protected $description = 'Shorten a URL using the registered service';
 
     public function handle(): int
     {

--- a/src/Commands/LaravelShortenUrlsCommand.php
+++ b/src/Commands/LaravelShortenUrlsCommand.php
@@ -16,7 +16,7 @@ class LaravelShortenUrlsCommand extends Command
     /** @var string $description */
     protected $description = 'Shorten an URL using the registered service';
 
-    public function handle(): void
+    public function handle(): int
     {
         $service = $this->getLaravel()->make(UrlShorteningService::class);
 
@@ -40,5 +40,7 @@ class LaravelShortenUrlsCommand extends Command
                 ],
             ],
         );
+
+        return self::SUCCESS;
     }
 }

--- a/src/Exceptions/ApiConfigurationError.php
+++ b/src/Exceptions/ApiConfigurationError.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CarAndClassic\LaravelShortenUrls\Exceptions;
+
+use Exception;
+
+class ApiConfigurationError extends Exception
+{
+}

--- a/src/Services/Shortio.php
+++ b/src/Services/Shortio.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CarAndClassic\LaravelShortenUrls\Services;
+
+use CarAndClassic\LaravelShortenUrls\Contracts\UrlShorteningService;
+use CarAndClassic\LaravelShortenUrls\Exceptions\ApiConfigurationError;
+use CarAndClassic\LaravelShortenUrls\Exceptions\ApiResponseFailure;
+use CarAndClassic\LaravelShortenUrls\Values\ShortLink;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class Shortio implements UrlShorteningService
+{
+
+    public function shortenUrl(string $url, array $additionalParams = []): ?ShortLink
+    {
+        $domain = (string)config('shorten-urls.provider-list.shortio.domain');
+        $apiKey = (string)config('shorten-urls.provider-list.shortio.api_key');
+
+        if (empty($apiKey)) {
+            throw new ApiConfigurationError('Short.io Configuration Error: Missing Api Key');
+        }
+
+        if (empty($domain)) {
+            throw new ApiConfigurationError('Short.io Configuration Error: Missing Domain');
+        }
+
+//        try {
+        $settings = array_merge(
+            $additionalParams,
+            [
+                'originalURL' => $url,
+                'domain' => $domain
+            ]
+        );
+
+        $client = new Client();
+        try {
+            $response = $client->request(
+                'POST',
+                'https://api.short.io/links',
+                [
+                    'body' => $settings,
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Authorization' => $apiKey,
+                        'Content-Type' => 'application/json',
+                    ],
+
+                ]
+            );
+        } catch (GuzzleException $e) {
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            throw new ApiResponseFailure(
+                'Short.io Response error:' . $response->getBody()->getContents(),
+                $response->getStatusCode()
+            );
+        }
+
+        return ShortLink::create('https://www.google.com');
+    }
+}


### PR DESCRIPTION
This Feature adds support for Short.io as per request.

This closes #2.

## Testing:
- update composer.json in project so that it has `"carandclassic/laravel-shorten-urls": "dev-feature/shortio-support",`
- run `composer update -W carandclassic/laravel-shorten-urls`
- update config - copy the shortio config options from the package config/shorten-urls.php to the app's version - if there is no version you can use `php artisan vendor:publish --tag=laravel-shorten-urls-config` to publish the file.
- change the provider in the config to `shortio`
- make sure you have the SHORTIO_API_KEY and SHORTIO_API_DOMAIN set appropriately in your .env OR update the config to have these values
- flush config
- run the artisan command ` php artisan url:shorten https://google.com` to see the short url
- log into short.io to see the short url created and listed in dashboard.


## Notes
As a note - this, by default, only uses the basic of functionality to provide support. 
If the url shortening is used in code, additional parameters from the request are available to be passed through to the second option of the `shortenUrl` method.

